### PR TITLE
Added travis pipeline for citrus-samples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,313 +1,306 @@
 language: java
 jdk:
-  - openjdk8
+- openjdk8
 
 dist: trusty
-sudo: required
 
-# infinite depth for better sonar metrics
-git:
-  depth: false
-
-# Skip installation step
 install: true
 
 jobs:
   include:
     - stage: install-todo-app
-      script: mvn clean install -pl :citrus-sample-todo
-
+      script:
+      - mvn clean install -pl :citrus-sample-todo
     - stage: it-citrus-java-sample-annotation-config
-      script: mvn verify -Dembedded -pl :citrus-java-sample-annotation-config
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-annotation-config
     - stage: it-citrus-java-sample-behaviors
-      script: mvn verify -Dembedded -pl :citrus-java-sample-behaviors
-
+      script: 
+      - mvn verify -Dembedded -pl :citrus-java-sample-behaviors
     - stage: it-citrus-java-sample-binary
-      script: mvn verify -Dembedded -pl :citrus-java-sample-binary
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-binary
     - stage: it-citrus-java-sample-camel-context
-      script: mvn verify -Dembedded -pl :citrus-java-sample-camel-context
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-camel-context
     - stage: it-citrus-java-sample-disctionaries
-      script: mvn verify -Dembedded -pl :citrus-java-sample-dictionaries
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-dictionaries
     - stage: it-citrus-java-sample-docker
-      script: mvn verify -Dembedded -pl :citrus-java-sample-docker
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-docker
     - stage: it-citrus-java-sample-dynamic-endpoints
-      script: mvn verify -Dembedded -pl :citrus-java-sample-dynamic-endpoints
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-dynamic-endpoints
     - stage: it-citrus-java-sample-hamcrest
-      script: mvn verify -Dembedded -pl :citrus-java-sample-hamcrest
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-hamcrest
     - stage: it-citrus-java-sample-javaconfig
-      script: mvn verify -Dembedded -pl :citrus-java-sample-javaconfig
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-javaconfig
     - stage: it-citrus-java-sample-jms
-      script: mvn verify -Dembedded -pl :citrus-java-sample-jms
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-jms
     - stage: it-citrus-java-sample-kafka
-      script: mvn verify -Dembedded -pl :citrus-java-sample-kafka
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-kafka
     - stage: it-citrus-java-sample-kubernetes
-      script: mvn verify -Dembedded -pl :citrus-java-sample-kubernetes
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-kubernetes
     - stage: it-citrus-java-sample-mail
-      script: mvn verify -Dembedded -pl :citrus-java-sample-mail
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-mail
     - stage: it-citrus-java-sample-message-store
-      script: mvn verify -Dembedded -pl :citrus-java-sample-message-store
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-message-store
     - stage: it-citrus-java-sample-reporting
-      script: mvn verify -Dembedded -pl :citrus-java-sample-reporting
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-reporting
     - stage: it-citrus-java-sample-rmi
-      script: mvn verify -Dembedded -pl :citrus-java-sample-rmi
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-rmi
 #   TODO: get selenium running on travis
 #    - stage: it-citrus-java-sample-selenium
-#      script: mvn verify -Dembedded -pl :citrus-java-sample-selenium
-
+#      script:
+#      - mvn verify -Dembedded -pl :citrus-java-sample-selenium
     - stage: it-citrus-java-sample-cucumber
-      script: mvn verify -Dembedded -pl :citrus-java-sample-cucumber
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-cucumber
     - stage: it-citrus-java-sample-cucumber-spring
-      script: mvn verify -Dembedded -pl :citrus-java-sample-cucumber-spring
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-cucumber-spring
     - stage: it-citrus-java-sample-cucumber2
-      script: mvn verify -Dembedded -pl :citrus-java-sample-cucumber-spring2
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-cucumber-spring2
     - stage: it-citrus-java-sample-jdbc
-      script: mvn verify -Dembedded -pl :citrus-java-sample-jdbc
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-jdbc
     - stage: it-citrus-java-sample-jdbc-callable-statements
-      script: mvn verify -Dembedded -pl :citrus-java-sample-jdbc-callable-statements
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-jdbc-callable-statements
     - stage: it-citrus-java-sample-jdbc-transactions
-      script: mvn verify -Dembedded -pl :citrus-java-sample-jdbc-transactions
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-jdbc-transactions
     - stage: it-citrus-java-sample-sql
-      script: mvn verify -Dembedded -pl :citrus-java-sample-sql
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-sql
     - stage: it-citrus-java-sample-ftp
-      script: mvn verify -Dembedded -pl :citrus-java-sample-ftp
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-ftp
     - stage: it-citrus-java-sample-scp
-      script: mvn verify -Dembedded -pl :citrus-java-sample-scp
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-scp
     - stage: it-citrus-java-sample-sftp
-      script: mvn verify -Dembedded -pl :citrus-java-sample-sftp
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-sftp
     - stage: it-citrus-java-sample-http
-      script: mvn verify -Dembedded -pl :citrus-java-sample-http
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-http
     - stage: it-citrus-java-sample-http-basic-auth
-      script: mvn verify -Dembedded -pl :citrus-java-sample-http-basic-auth
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-http-basic-auth
     - stage: it-citrus-java-sample-http-form-data
-      script: mvn verify -Dembedded -pl :citrus-java-sample-http-form-data
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-http-form-data
 #    TODO: throws ConcurrentModificationException
 #    - stage: it-citrus-java-sample-http-loadtest
-#      script: mvn verify -Dembedded -pl :citrus-java-sample-http-loadtest
-
+#      script:
+#      - mvn verify -Dembedded -pl :citrus-java-sample-http-loadtest
     - stage: it-citrus-java-sample-http-query-param
-      script: mvn verify -Dembedded -pl :citrus-java-sample-http-query-param
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-http-query-param
     - stage: it-citrus-java-sample-http-static-response
-      script: mvn verify -Dembedded -pl :citrus-java-sample-http-static-response
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-http-static-response
     - stage: it-citrus-java-sample-https
-      script: mvn verify -Dembedded -pl :citrus-java-sample-https
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-https
     - stage: it-citrus-java-sample-swagger
-      script: mvn verify -Dembedded -pl :citrus-java-sample-swagger
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-swagger
     - stage: it-citrus-java-sample-databind
-      script: mvn verify -Dembedded -pl :citrus-java-sample-databind
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-databind
     - stage: it-citrus-java-sample-json
-      script: mvn verify -Dembedded -pl :citrus-java-sample-json
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-json
     - stage: it-citrus-java-sample-junit
-      script: mvn verify -Dembedded -pl :citrus-java-sample-junit
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-junit
     - stage: it-citrus-java-sample-junit5
-      script: mvn verify -Dembedded -pl :citrus-java-sample-junit5
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-junit5
     - stage: it-citrus-java-sample-test-jar
-      script: mvn verify -Dembedded -pl :citrus-java-sample-test-jar
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-test-jar
 #    TODO: The jetty-plugin is not properly configured, the server returns a 404 on every request
 #    - stage: it-citrus-java-sample-test-war
-#      script: mvn verify -Dembedded -pl :citrus-java-sample-test-war
-
+#      script:
+#      - mvn verify -Dembedded -pl :citrus-java-sample-test-war
     - stage: it-citrus-java-sample-soap
-      script: mvn verify -Dembedded -pl :citrus-java-sample-soap
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-soap
     - stage: it-citrus-java-sample-soap-attachment
-      script: mvn verify -Dembedded -pl :citrus-java-sample-soap-attachment
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-soap-attachment
     - stage: it-citrus-java-sample-soap-mtom
-      script: mvn verify -Dembedded -pl :citrus-java-sample-soap-mtom
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-soap-mtom
     - stage: it-citrus-java-sample-soap-ssl
-      script: mvn verify -Dembedded -pl :citrus-java-sample-soap-ssl
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-soap-ssl
     - stage: it-citrus-java-sample-soap-static-response
-      script: mvn verify -Dembedded -pl :citrus-java-sample-soap-static-response
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-soap-static-response
     - stage: it-citrus-java-sample-soap-wsaddressing
-      script: mvn verify -Dembedded -pl :citrus-java-sample-soap-wsaddressing
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-soap-wsaddressing
     - stage: it-citrus-java-sample-soap-wssecurity
-      script: mvn verify -Dembedded -pl :citrus-java-sample-soap-wssecurity
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-soap-wssecurity
     - stage: it-citrus-java-sample-wsdl
-      script: mvn verify -Dembedded -pl :citrus-java-sample-wsdl
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-wsdl
     - stage: it-citrus-java-sample-dataprovider
-      script: mvn verify -Dembedded -pl :citrus-java-sample-dataprovider
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-dataprovider
     - stage: it-citrus-java-sample-testng
-      script: mvn verify -Dembedded -pl :citrus-java-sample-testng
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-testng
     - stage: it-citrus-java-sample-oxm
-      script: mvn verify -Dembedded -pl :citrus-java-sample-oxm
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-oxm
     - stage: it-citrus-java-sample-xhtml
-      script: mvn verify -Dembedded -pl :citrus-java-sample-xhtml
-
-# Here be dragons (aka. xml tests)
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-java-sample-xhtml
     - stage: it-citrus-xml-sample-camel-context
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-camel-context
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-camel-context
     - stage: it-citrus-xml-sample-disctionaries
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-dictionaries
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-dictionaries
     - stage: it-citrus-xml-sample-docker
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-docker
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-docker
     - stage: it-citrus-xml-sample-dynamic-endpoints
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-dynamic-endpoints
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-dynamic-endpoints
     - stage: it-citrus-xml-sample-hamcrest
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-hamcrest
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-hamcrest
     - stage: it-citrus-xml-sample-jms
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-jms
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-jms
     - stage: it-citrus-xml-sample-kafka
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-kafka
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-kafka
     - stage: it-citrus-xml-sample-kubernetes
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-kubernetes
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-kubernetes
     - stage: it-citrus-xml-sample-mail
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-mail
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-mail
     - stage: it-citrus-xml-sample-message-store
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-message-store
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-message-store
     - stage: it-citrus-xml-sample-reporting
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-reporting
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-reporting
     - stage: it-citrus-xml-sample-rmi
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-rmi
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-rmi
     - stage: it-citrus-xml-sample-ftp
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-ftp
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-ftp
 #   TODO: get selenium running on travis
 #    - stage: it-citrus-xml-sample-selenium
-#      script: mvn verify -Dembedded -pl :citrus-xml-sample-selenium
-
+#      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-selenium
     - stage: it-citrus-xml-sample-cucumber
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-cucumber
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-cucumber
     - stage: it-citrus-xml-sample-cucumber-spring
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-cucumber-spring
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-cucumber-spring
     - stage: it-citrus-xml-sample-cucumber2
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-cucumber-spring2
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-cucumber-spring2
     - stage: it-citrus-xml-sample-jdbc
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-jdbc
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-jdbc
     - stage: it-citrus-xml-sample-jdbc-callable-statements
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-jdbc-callable-statements
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-jdbc-callable-statements
     - stage: it-citrus-xml-sample-jdbc-transactions
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-jdbc-transactions
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-jdbc-transactions
     - stage: it-citrus-xml-sample-sql
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-sql
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-sql
     - stage: it-citrus-xml-sample-scp
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-scp
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-scp
     - stage: it-citrus-xml-sample-sftp
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-sftp
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-sftp
     - stage: it-citrus-xml-sample-http
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-http
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-http
     - stage: it-citrus-xml-sample-http-basic-auth
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-http-basic-auth
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-http-basic-auth
     - stage: it-citrus-xml-sample-http-form-data
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-http-form-data
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-http-form-data
 #    TODO: throws ConcurrentModificationException
 #    - stage: it-citrus-xml-sample-http-loadtest
-#      script: mvn verify -Dembedded -pl :citrus-xml-sample-http-loadtest
-
+#      script:
+#      - mvn verify -Dembedded -pl :citrus-xml-sample-http-loadtest
     - stage: it-citrus-xml-sample-http-query-param
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-http-query-param
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-http-query-param
     - stage: it-citrus-xml-sample-http-static-response
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-http-static-response
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-http-static-response
     - stage: it-citrus-xml-sample-https
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-https
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-https
     - stage: it-citrus-xml-sample-json
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-json
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-json
     - stage: it-citrus-xml-sample-junit
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-junit
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-junit
     - stage: it-citrus-xml-sample-junit5
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-junit5
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-junit5
     - stage: it-citrus-xml-sample-soap
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-soap
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-soap
     - stage: it-citrus-xml-sample-soap-attachment
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-soap-attachment
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-soap-attachment
     - stage: it-citrus-xml-sample-soap-ssl
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-soap-ssl
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-soap-ssl
     - stage: it-citrus-xml-sample-soap-static-response
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-soap-static-response
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-soap-static-response
     - stage: it-citrus-xml-sample-soap-wsaddressing
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-soap-wsaddressing
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-soap-wsaddressing
     - stage: it-citrus-xml-sample-soap-wssecurity
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-soap-wssecurity
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-soap-wssecurity
     - stage: it-citrus-xml-sample-dataprovider
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-dataprovider
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-dataprovider
     - stage: it-citrus-xml-sample-testng
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-testng
-
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-testng
     - stage: it-citrus-xml-sample-xhtml
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-xhtml
+      script:
+      - mvn verify -Dembedded -pl :citrus-xml-sample-xhtml
 
 stages:
   - install-todo-app
@@ -327,7 +320,7 @@ stages:
   - it-citrus-java-sample-message-store
   - it-citrus-java-sample-reporting
   - it-citrus-java-sample-rmi
-  #  - it-citrus-java-sample-selenium
+#  - it-citrus-java-sample-selenium
   - it-citrus-java-sample-cucumber
   - it-citrus-java-sample-cucumber-spring
   - it-citrus-java-sample-cucumber2
@@ -364,7 +357,6 @@ stages:
   - it-citrus-java-sample-testng
   - it-citrus-java-sample-oxm
   - it-citrus-java-sample-xhtml
-
   - it-citrus-xml-sample-binary
   - it-citrus-xml-sample-camel-context
   - it-citrus-xml-sample-disctionaries

--- a/.travis.yml
+++ b/.travis.yml
@@ -215,7 +215,7 @@ jobs:
 #   TODO: get selenium running on travis
 #    - stage: it-citrus-xml-sample-selenium
 #      script:
-      - mvn verify -Dembedded -pl :citrus-xml-sample-selenium
+#      - mvn verify -Dembedded -pl :citrus-xml-sample-selenium
     - stage: it-citrus-xml-sample-cucumber
       script:
       - mvn verify -Dembedded -pl :citrus-xml-sample-cucumber

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: java
+jdk:
+  - openjdk8
+
+dist: trusty
+sudo: required
+
+# infinite depth for better sonar metrics
+git:
+  depth: false
+
+branches:
+  only:
+    - feature-add-travis-pipeline
+
+# Skip installation step
+install: true
+
+jobs:
+  include:
+    - stage: install-todo-app
+      script mvn install -pl :citrus-sample-todo
+
+cache:
+  directories:
+    - '$HOME/.sonar/cache'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install: true
 jobs:
   include:
     - stage: install-todo-app
-      script mvn install -pl :citrus-sample-todo
+      script: mvn install -pl :citrus-sample-todo
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,391 @@ install: true
 jobs:
   include:
     - stage: install-todo-app
-      script: mvn install -pl :citrus-sample-todo
+      script: mvn clean install -pl :citrus-sample-todo
+
+    - stage: it-citrus-java-sample-annotation-config
+      script: mvn verify -Dembedded -pl :citrus-java-sample-annotation-config
+
+    - stage: it-citrus-java-sample-behaviors
+      script: mvn verify -Dembedded -pl :citrus-java-sample-behaviors
+
+    - stage: it-citrus-java-sample-binary
+      script: mvn verify -Dembedded -pl :citrus-java-sample-binary
+
+    - stage: it-citrus-java-sample-camel-context
+      script: mvn verify -Dembedded -pl :citrus-java-sample-camel-context
+
+    - stage: it-citrus-java-sample-disctionaries
+      script: mvn verify -Dembedded -pl :citrus-java-sample-dictionaries
+
+    - stage: it-citrus-java-sample-docker
+      script: mvn verify -Dembedded -pl :citrus-java-sample-docker
+
+    - stage: it-citrus-java-sample-dynamic-endpoints
+      script: mvn verify -Dembedded -pl :citrus-java-sample-dynamic-endpoints
+
+    - stage: it-citrus-java-sample-hamcrest
+      script: mvn verify -Dembedded -pl :citrus-java-sample-hamcrest
+
+    - stage: it-citrus-java-sample-javaconfig
+      script: mvn verify -Dembedded -pl :citrus-java-sample-javaconfig
+
+    - stage: it-citrus-java-sample-jms
+      script: mvn verify -Dembedded -pl :citrus-java-sample-jms
+
+    - stage: it-citrus-java-sample-kafka
+      script: mvn verify -Dembedded -pl :citrus-java-sample-kafka
+
+    - stage: it-citrus-java-sample-kubernetes
+      script: mvn verify -Dembedded -pl :citrus-java-sample-kubernetes
+
+    - stage: it-citrus-java-sample-mail
+      script: mvn verify -Dembedded -pl :citrus-java-sample-mail
+
+    - stage: it-citrus-java-sample-message-store
+      script: mvn verify -Dembedded -pl :citrus-java-sample-message-store
+
+    - stage: it-citrus-java-sample-reporting
+      script: mvn verify -Dembedded -pl :citrus-java-sample-reporting
+
+    - stage: it-citrus-java-sample-rmi
+      script: mvn verify -Dembedded -pl :citrus-java-sample-rmi
+
+#   TODO: check for headless selenium driver
+#    - stage: it-citrus-java-sample-selenium
+#      script: mvn verify -Dembedded -pl :citrus-java-sample-selenium
+
+    - stage: it-citrus-sample-cucumber-spring
+      script: mvn verify -Dembedded -pl :citrus-sample-cucumber-spring
+
+    - stage: it-citrus-sample-cucumber2
+      script: mvn verify -Dembedded -pl :citrus-sample-cucumber-spring2
+
+#   TODO: check "address already in use"
+#    - stage: it-citrus-java-sample-jdbc
+#      script: mvn verify -Dembedded -pl :citrus-java-sample-jdbc
+#
+#    - stage: it-citrus-java-sample-jdbc-callable-statements
+#      script: mvn verify -Dembedded -pl :citrus-java-sample-jdbc-callable-statements
+#
+#    - stage: it-citrus-java-sample-jdbc-transactions
+#      script: mvn verify -Dembedded -pl :citrus-java-sample-jdbc-transactions
+#   :ODOT
+
+    - stage: it-citrus-java-sample-sql
+      script: mvn verify -Dembedded -pl :citrus-java-sample-sql
+
+
+    - stage: it-citrus-java-sample-sql
+      script: mvn verify -Dembedded -pl :citrus-java-sample-sql
+
+
+    - stage: it-citrus-java-sample-ftp
+      script: mvn verify -Dembedded -pl :citrus-java-sample-ftp
+
+    - stage: it-citrus-java-sample-scp
+      script: mvn verify -Dembedded -pl :citrus-java-sample-scp
+
+    - stage: it-citrus-java-sample-sftp
+      script: mvn verify -Dembedded -pl :citrus-java-sample-sftp
+
+    - stage: it-citrus-java-sample-http
+      script: mvn verify -Dembedded -pl :citrus-java-sample-http
+
+    - stage: it-citrus-java-sample-http-basic-auth
+      script: mvn verify -Dembedded -pl :citrus-java-sample-http-basic-auth
+
+    - stage: it-citrus-java-sample-http-form-data
+      script: mvn verify -Dembedded -pl :citrus-java-sample-http-form-data
+
+#    TODO: throws ConcurrentModificationException
+#    - stage: it-citrus-java-sample-http-loadtest
+#      script: mvn verify -Dembedded -pl :citrus-java-sample-http-loadtest
+
+    - stage: it-citrus-java-sample-http-query-param
+      script: mvn verify -Dembedded -pl :citrus-java-sample-http-query-param
+
+    - stage: it-citrus-java-sample-http-static-response
+      script: mvn verify -Dembedded -pl :citrus-java-sample-http-static-response
+
+    - stage: it-citrus-java-sample-https
+      script: mvn verify -Dembedded -pl :citrus-java-sample-https
+
+    - stage: it-citrus-java-sample-swagger
+      script: mvn verify -Dembedded -pl :citrus-java-sample-swagger
+
+    - stage: it-citrus-java-sample-databind
+      script: mvn verify -Dembedded -pl :citrus-java-sample-databind
+
+    - stage: it-citrus-java-sample-json
+      script: mvn verify -Dembedded -pl :citrus-java-sample-json
+
+    - stage: it-citrus-java-sample-junit
+      script: mvn verify -Dembedded -pl :citrus-java-sample-junit
+
+    - stage: it-citrus-java-sample-junit5
+      script: mvn verify -Dembedded -pl :citrus-java-sample-junit5
+
+    - stage: it-citrus-java-sample-test-jar
+      script: mvn verify -Dembedded -pl :citrus-java-sample-test-jar
+
+#    TODO: java.net.SocketException: Connection reset
+#    - stage: it-citrus-java-sample-test-war
+#      script: mvn verify -Dembedded -pl :citrus-java-sample-test-war
+
+    - stage: it-citrus-java-sample-soap
+      script: mvn verify -Dembedded -pl :citrus-java-sample-soap
+
+    - stage: it-citrus-java-sample-soap-attachment
+      script: mvn verify -Dembedded -pl :citrus-java-sample-soap-attachment
+
+    - stage: it-citrus-java-sample-soap-motm
+      script: mvn verify -Dembedded -pl :citrus-java-sample-soap-mtom
+
+    - stage: it-citrus-java-sample-soap-ssl
+      script: mvn verify -Dembedded -pl :citrus-java-sample-soap-ssl
+
+    - stage: it-citrus-java-sample-soap-static-response
+      script: mvn verify -Dembedded -pl :citrus-java-sample-soap-static-response
+
+    - stage: it-citrus-java-sample-soap-wsaddressing
+      script: mvn verify -Dembedded -pl :citrus-java-sample-soap-wsaddressing
+
+    - stage: it-citrus-java-sample-soap-wssecurity
+      script: mvn verify -Dembedded -pl :citrus-java-sample-soap-wssecurity
+
+    - stage: it-citrus-java-sample-wsdl
+      script: mvn verify -Dembedded -pl :citrus-java-sample-wsdl
+
+    - stage: it-citrus-java-sample-dataprovider
+      script: mvn verify -Dembedded -pl :citrus-java-sample-dataprovider
+
+    - stage: it-citrus-java-sample-testng
+      script: mvn verify -Dembedded -pl :citrus-java-sample-testng
+
+    - stage: it-citrus-java-sample-oxm
+      script: mvn verify -Dembedded -pl :citrus-java-sample-oxm
+
+    - stage: it-citrus-java-sample-xhtml
+      script: mvn verify -Dembedded -pl :citrus-java-sample-xhtml
+
+# Here be dragons (aka. xml tests)
+
+    - stage: it-citrus-xml-sample-behaviors
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-behaviors
+
+    - stage: it-citrus-xml-sample-camel-context
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-camel-context
+
+    - stage: it-citrus-xml-sample-disctionaries
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-dictionaries
+
+    - stage: it-citrus-xml-sample-docker
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-docker
+
+    - stage: it-citrus-xml-sample-dynamic-endpoints
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-dynamic-endpoints
+
+    - stage: it-citrus-xml-sample-hamcrest
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-hamcrest
+
+    - stage: it-citrus-xml-sample-jms
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-jms
+
+    - stage: it-citrus-xml-sample-kafka
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-kafka
+
+    - stage: it-citrus-xml-sample-kubernetes
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-kubernetes
+
+    - stage: it-citrus-xml-sample-mail
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-mail
+
+    - stage: it-citrus-xml-sample-message-store
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-message-store
+
+    - stage: it-citrus-xml-sample-reporting
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-reporting
+
+    - stage: it-citrus-xml-sample-rmi
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-rmi
+
+    - stage: it-citrus-xml-sample-ftp
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-ftp
+
+#   TODO: check for headless selenium driver
+#    - stage: it-citrus-xml-sample-selenium
+#      script: mvn verify -Dembedded -pl :citrus-xml-sample-selenium
+
+#   TODO: check "address already in use"
+#    - stage: it-citrus-xml-sample-jdbc
+#      script: mvn verify -Dembedded -pl :citrus-xml-sample-jdbc
+#
+#    - stage: it-citrus-xml-sample-jdbc-callable-statements
+#      script: mvn verify -Dembedded -pl :citrus-xml-sample-jdbc-callable-statements
+#
+#    - stage: it-citrus-xml-sample-jdbc-transactions
+#      script: mvn verify -Dembedded -pl :citrus-xml-sample-jdbc-transactions
+#   :ODOT
+
+    - stage: it-citrus-xml-sample-sql
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-sql
+
+    - stage: it-citrus-xml-sample-scp
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-scp
+
+    - stage: it-citrus-xml-sample-sftp
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-sftp
+
+    - stage: it-citrus-xml-sample-http
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-http
+
+    - stage: it-citrus-xml-sample-http-basic-auth
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-http-basic-auth
+
+    - stage: it-citrus-xml-sample-http-form-data
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-http-form-data
+
+#    TODO: throws ConcurrentModificationException
+#    - stage: it-citrus-xml-sample-http-loadtest
+#      script: mvn verify -Dembedded -pl :citrus-xml-sample-http-loadtest
+
+    - stage: it-citrus-xml-sample-http-query-param
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-http-query-param
+
+    - stage: it-citrus-xml-sample-http-static-response
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-http-static-response
+
+    - stage: it-citrus-xml-sample-https
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-https
+
+    - stage: it-citrus-xml-sample-json
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-json
+
+    - stage: it-citrus-xml-sample-junit
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-junit
+
+    - stage: it-citrus-xml-sample-junit5
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-junit5
+
+    - stage: it-citrus-xml-sample-soap
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-soap
+
+    - stage: it-citrus-xml-sample-soap-attachment
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-soap-attachment
+
+    - stage: it-citrus-xml-sample-soap-ssl
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-soap-ssl
+
+    - stage: it-citrus-xml-sample-soap-static-response
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-soap-static-response
+
+    - stage: it-citrus-xml-sample-soap-wsaddressing
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-soap-wsaddressing
+
+    - stage: it-citrus-xml-sample-soap-wssecurity
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-soap-wssecurity
+
+    - stage: it-citrus-xml-sample-dataprovider
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-dataprovider
+
+    - stage: it-citrus-xml-sample-testng
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-testng
+
+    - stage: it-citrus-xml-sample-xhtml
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-xhtml
+
+stages:
+  - install-todo-app
+  - it-citrus-java-sample-annotation-config
+  - it-citrus-java-sample-behavior
+  - it-citrus-java-sample-binary
+  - it-citrus-java-sample-camel-context
+  - it-citrus-java-sample-disctionaries
+  - it-citrus-java-sample-docker
+  - it-citrus-java-sample-dynamic-endpoints
+  - it-citrus-java-sample-hamcrest
+  - it-citrus-java-sample-javaconfig
+  - it-citrus-java-sample-jms
+  - it-citrus-java-sample-kafka
+  - it-citrus-java-sample-kubernetes
+  - it-citrus-java-sample-mail
+  - it-citrus-java-sample-message-store
+  - it-citrus-java-sample-reporting
+  - it-citrus-java-sample-rmi
+  - it-citrus-sample-cucumber-spring
+  - it-citrus-sample-cucumber2
+  - it-citrus-java-sample-jdbc
+  - it-citrus-java-sample-jdbc-callable-statements
+  - it-citrus-java-sample-jdbc-transactions
+  - it-citrus-java-sample-sql
+  - it-citrus-java-sample-ftp
+  - it-citrus-java-sample-scp
+  - it-citrus-java-sample-sftp
+  - it-citrus-java-sample-http
+  - it-citrus-java-sample-http-basic-auth
+  - it-citrus-java-sample-http-form-data
+  - it-citrus-java-sample-http-query-param
+  - it-citrus-java-sample-http-static-response
+  - it-citrus-java-sample-https
+  - it-citrus-java-sample-swagger
+  - it-citrus-java-sample-databind
+  - it-citrus-java-sample-json
+  - it-citrus-java-sample-junit
+  - it-citrus-java-sample-junit5
+  - it-citrus-java-sample-test-jar
+  - it-citrus-java-sample-soap
+  - it-citrus-java-sample-soap-attachment
+  - it-citrus-java-sample-soap-attachment
+  - it-citrus-java-sample-soap-ssl
+  - it-citrus-java-sample-soap-static-response
+  - it-citrus-java-sample-soap-wsaddressing
+  - it-citrus-java-sample-soap-wssecurity
+  - it-citrus-java-sample-wsdl
+  - it-citrus-java-sample-dataprovider
+  - it-citrus-java-sample-testng
+  - it-citrus-java-sample-oxm
+  - it-citrus-java-sample-xhtml
+
+  - it-citrus-xml-sample-binary
+  - it-citrus-xml-sample-camel-context
+  - it-citrus-xml-sample-disctionaries
+  - it-citrus-xml-sample-docker
+  - it-citrus-xml-sample-dynamic-endpoints
+  - it-citrus-xml-sample-hamcrest
+  - it-citrus-xml-sample-jms
+  - it-citrus-xml-sample-kafka
+  - it-citrus-xml-sample-kubernetes
+  - it-citrus-xml-sample-mail
+  - it-citrus-xml-sample-message-store
+  - it-citrus-xml-sample-reporting
+  - it-citrus-xml-sample-rmi
+  - it-citrus-xml-sample-jdbc
+  - it-citrus-xml-sample-jdbc-callable-statements
+  - it-citrus-xml-sample-jdbc-transactions
+  - it-citrus-xml-sample-sql
+  - it-citrus-xml-sample-ftp
+  - it-citrus-xml-sample-scp
+  - it-citrus-xml-sample-sftp
+  - it-citrus-xml-sample-http
+  - it-citrus-xml-sample-http-basic-auth
+  - it-citrus-xml-sample-http-form-data
+  - it-citrus-xml-sample-http-query-param
+  - it-citrus-xml-sample-http-static-response
+  - it-citrus-xml-sample-https
+  - it-citrus-xml-sample-json
+  - it-citrus-xml-sample-junit
+  - it-citrus-xml-sample-junit5
+  - it-citrus-xml-sample-soap
+  - it-citrus-xml-sample-soap-attachment
+  - it-citrus-xml-sample-soap-ssl
+  - it-citrus-xml-sample-soap-static-response
+  - it-citrus-xml-sample-soap-wsaddressing
+  - it-citrus-xml-sample-soap-wssecurity
+  - it-citrus-xml-sample-dataprovider
+  - it-citrus-xml-sample-testng
+  - it-citrus-xml-sample-xhtml
 
 cache:
   directories:
-    - '$HOME/.sonar/cache'
+    - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ sudo: required
 git:
   depth: false
 
-branches:
-  only:
-    - feature-add-travis-pipeline
-
 # Skip installation step
 install: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,34 +65,30 @@ jobs:
     - stage: it-citrus-java-sample-rmi
       script: mvn verify -Dembedded -pl :citrus-java-sample-rmi
 
-#   TODO: check for headless selenium driver
+#   TODO: get selenium running on travis
 #    - stage: it-citrus-java-sample-selenium
 #      script: mvn verify -Dembedded -pl :citrus-java-sample-selenium
 
-    - stage: it-citrus-sample-cucumber-spring
-      script: mvn verify -Dembedded -pl :citrus-sample-cucumber-spring
+    - stage: it-citrus-java-sample-cucumber
+      script: mvn verify -Dembedded -pl :citrus-java-sample-cucumber
 
-    - stage: it-citrus-sample-cucumber2
-      script: mvn verify -Dembedded -pl :citrus-sample-cucumber-spring2
+    - stage: it-citrus-java-sample-cucumber-spring
+      script: mvn verify -Dembedded -pl :citrus-java-sample-cucumber-spring
 
-#   TODO: check "address already in use"
-#    - stage: it-citrus-java-sample-jdbc
-#      script: mvn verify -Dembedded -pl :citrus-java-sample-jdbc
-#
-#    - stage: it-citrus-java-sample-jdbc-callable-statements
-#      script: mvn verify -Dembedded -pl :citrus-java-sample-jdbc-callable-statements
-#
-#    - stage: it-citrus-java-sample-jdbc-transactions
-#      script: mvn verify -Dembedded -pl :citrus-java-sample-jdbc-transactions
-#   :ODOT
+    - stage: it-citrus-java-sample-cucumber2
+      script: mvn verify -Dembedded -pl :citrus-java-sample-cucumber-spring2
 
-    - stage: it-citrus-java-sample-sql
-      script: mvn verify -Dembedded -pl :citrus-java-sample-sql
+    - stage: it-citrus-java-sample-jdbc
+      script: mvn verify -Dembedded -pl :citrus-java-sample-jdbc
 
+    - stage: it-citrus-java-sample-jdbc-callable-statements
+      script: mvn verify -Dembedded -pl :citrus-java-sample-jdbc-callable-statements
+
+    - stage: it-citrus-java-sample-jdbc-transactions
+      script: mvn verify -Dembedded -pl :citrus-java-sample-jdbc-transactions
 
     - stage: it-citrus-java-sample-sql
       script: mvn verify -Dembedded -pl :citrus-java-sample-sql
-
 
     - stage: it-citrus-java-sample-ftp
       script: mvn verify -Dembedded -pl :citrus-java-sample-ftp
@@ -143,7 +139,7 @@ jobs:
     - stage: it-citrus-java-sample-test-jar
       script: mvn verify -Dembedded -pl :citrus-java-sample-test-jar
 
-#    TODO: java.net.SocketException: Connection reset
+#    TODO: The jetty-plugin is not properly configured, the server returns a 404 on every request
 #    - stage: it-citrus-java-sample-test-war
 #      script: mvn verify -Dembedded -pl :citrus-java-sample-test-war
 
@@ -153,7 +149,7 @@ jobs:
     - stage: it-citrus-java-sample-soap-attachment
       script: mvn verify -Dembedded -pl :citrus-java-sample-soap-attachment
 
-    - stage: it-citrus-java-sample-soap-motm
+    - stage: it-citrus-java-sample-soap-mtom
       script: mvn verify -Dembedded -pl :citrus-java-sample-soap-mtom
 
     - stage: it-citrus-java-sample-soap-ssl
@@ -184,9 +180,6 @@ jobs:
       script: mvn verify -Dembedded -pl :citrus-java-sample-xhtml
 
 # Here be dragons (aka. xml tests)
-
-    - stage: it-citrus-xml-sample-behaviors
-      script: mvn verify -Dembedded -pl :citrus-xml-sample-behaviors
 
     - stage: it-citrus-xml-sample-camel-context
       script: mvn verify -Dembedded -pl :citrus-xml-sample-camel-context
@@ -227,20 +220,27 @@ jobs:
     - stage: it-citrus-xml-sample-ftp
       script: mvn verify -Dembedded -pl :citrus-xml-sample-ftp
 
-#   TODO: check for headless selenium driver
+#   TODO: get selenium running on travis
 #    - stage: it-citrus-xml-sample-selenium
 #      script: mvn verify -Dembedded -pl :citrus-xml-sample-selenium
 
-#   TODO: check "address already in use"
-#    - stage: it-citrus-xml-sample-jdbc
-#      script: mvn verify -Dembedded -pl :citrus-xml-sample-jdbc
-#
-#    - stage: it-citrus-xml-sample-jdbc-callable-statements
-#      script: mvn verify -Dembedded -pl :citrus-xml-sample-jdbc-callable-statements
-#
-#    - stage: it-citrus-xml-sample-jdbc-transactions
-#      script: mvn verify -Dembedded -pl :citrus-xml-sample-jdbc-transactions
-#   :ODOT
+    - stage: it-citrus-xml-sample-cucumber
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-cucumber
+
+    - stage: it-citrus-xml-sample-cucumber-spring
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-cucumber-spring
+
+    - stage: it-citrus-xml-sample-cucumber2
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-cucumber-spring2
+
+    - stage: it-citrus-xml-sample-jdbc
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-jdbc
+
+    - stage: it-citrus-xml-sample-jdbc-callable-statements
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-jdbc-callable-statements
+
+    - stage: it-citrus-xml-sample-jdbc-transactions
+      script: mvn verify -Dembedded -pl :citrus-xml-sample-jdbc-transactions
 
     - stage: it-citrus-xml-sample-sql
       script: mvn verify -Dembedded -pl :citrus-xml-sample-sql
@@ -312,7 +312,7 @@ jobs:
 stages:
   - install-todo-app
   - it-citrus-java-sample-annotation-config
-  - it-citrus-java-sample-behavior
+  - it-citrus-java-sample-behaviors
   - it-citrus-java-sample-binary
   - it-citrus-java-sample-camel-context
   - it-citrus-java-sample-disctionaries
@@ -327,8 +327,10 @@ stages:
   - it-citrus-java-sample-message-store
   - it-citrus-java-sample-reporting
   - it-citrus-java-sample-rmi
-  - it-citrus-sample-cucumber-spring
-  - it-citrus-sample-cucumber2
+  #  - it-citrus-java-sample-selenium
+  - it-citrus-java-sample-cucumber
+  - it-citrus-java-sample-cucumber-spring
+  - it-citrus-java-sample-cucumber2
   - it-citrus-java-sample-jdbc
   - it-citrus-java-sample-jdbc-callable-statements
   - it-citrus-java-sample-jdbc-transactions
@@ -339,6 +341,7 @@ stages:
   - it-citrus-java-sample-http
   - it-citrus-java-sample-http-basic-auth
   - it-citrus-java-sample-http-form-data
+#  - it-citrus-java-sample-http-loadtest
   - it-citrus-java-sample-http-query-param
   - it-citrus-java-sample-http-static-response
   - it-citrus-java-sample-https
@@ -348,9 +351,10 @@ stages:
   - it-citrus-java-sample-junit
   - it-citrus-java-sample-junit5
   - it-citrus-java-sample-test-jar
+#  - it-citrus-java-sample-test-war
   - it-citrus-java-sample-soap
   - it-citrus-java-sample-soap-attachment
-  - it-citrus-java-sample-soap-attachment
+  - it-citrus-java-sample-soap-mtom
   - it-citrus-java-sample-soap-ssl
   - it-citrus-java-sample-soap-static-response
   - it-citrus-java-sample-soap-wsaddressing
@@ -374,6 +378,10 @@ stages:
   - it-citrus-xml-sample-message-store
   - it-citrus-xml-sample-reporting
   - it-citrus-xml-sample-rmi
+#  - it-citrus-xml-sample-selenium
+  - it-citrus-xml-sample-cucumber
+  - it-citrus-xml-sample-cucumber-spring
+  - it-citrus-xml-sample-cucumber2
   - it-citrus-xml-sample-jdbc
   - it-citrus-xml-sample-jdbc-callable-statements
   - it-citrus-xml-sample-jdbc-transactions
@@ -384,6 +392,7 @@ stages:
   - it-citrus-xml-sample-http
   - it-citrus-xml-sample-http-basic-auth
   - it-citrus-xml-sample-http-form-data
+#  - it-citrus-xml-sample-http-loadtest
   - it-citrus-xml-sample-http-query-param
   - it-citrus-xml-sample-http-static-response
   - it-citrus-xml-sample-https

--- a/samples-db/sample-jdbc-callable-statements/java-dsl/pom.xml
+++ b/samples-db/sample-jdbc-callable-statements/java-dsl/pom.xml
@@ -69,7 +69,7 @@
         <configuration>
           <mainClass>com.consol.citrus.samples.todolist.TodoApplication</mainClass>
           <useTestClasspath>false</useTestClasspath>
-          <jvmArguments>-Dtodo.persistence.type=jdbc -Dtodo.persistence.server=disabled -Dtodo.jdbc.driverClassName=com.consol.citrus.db.driver.JdbcDriver -Dtodo.jdbc.url=jdbc:citrus:http://localhost:3306/testdb -Dtodo.jdbc.username=user -Dtodo.jdbc.password=password -Dtodo.jdbc.autoCreateTables=false</jvmArguments>
+          <jvmArguments>-Dtodo.persistence.type=jdbc -Dtodo.persistence.server=disabled -Dtodo.jdbc.driverClassName=com.consol.citrus.db.driver.JdbcDriver -Dtodo.jdbc.url=jdbc:citrus:http://localhost:13306/testdb -Dtodo.jdbc.username=user -Dtodo.jdbc.password=password -Dtodo.jdbc.autoCreateTables=false</jvmArguments>
         </configuration>
       </plugin>
 
@@ -97,7 +97,7 @@
                   <TODO_PERSISTENCE_TYPE>jdbc</TODO_PERSISTENCE_TYPE>
                   <TODO_JDBC_AUTO_CREATE_TABLES>false</TODO_JDBC_AUTO_CREATE_TABLES>
                   <TODO_JDBC_DRIVER>com.consol.citrus.db.driver.JdbcDriver</TODO_JDBC_DRIVER>
-                  <TODO_JDBC_URL>jdbc:citrus:http://${env.HOST_IP}:3306/testdb</TODO_JDBC_URL>
+                  <TODO_JDBC_URL>jdbc:citrus:http://${env.HOST_IP}:13306/testdb</TODO_JDBC_URL>
                 </env>
                 <log>
                   <enabled>true</enabled>

--- a/samples-db/sample-jdbc-callable-statements/java-dsl/src/test/java/com/consol/citrus/samples/todolist/EndpointConfig.java
+++ b/samples-db/sample-jdbc-callable-statements/java-dsl/src/test/java/com/consol/citrus/samples/todolist/EndpointConfig.java
@@ -54,7 +54,7 @@ public class EndpointConfig {
                 .server()
                 .host("localhost")
                 .databaseName("testdb")
-                .port(3306)
+                .port(13306)
                 .timeout(10000L)
                 .autoStart(true)
                 .autoCreateStatement(false)
@@ -65,7 +65,7 @@ public class EndpointConfig {
     public SingleConnectionDataSource dataSource() {
         SingleConnectionDataSource dataSource = new SingleConnectionDataSource();
         dataSource.setDriverClassName(JdbcDriver.class.getName());
-        dataSource.setUrl("jdbc:citrus:http://localhost:3306/testdb");
+        dataSource.setUrl("jdbc:citrus:http://localhost:13306/testdb");
         dataSource.setUsername("sa");
         dataSource.setPassword("");
         return dataSource;

--- a/samples-db/sample-jdbc-callable-statements/xml/pom.xml
+++ b/samples-db/sample-jdbc-callable-statements/xml/pom.xml
@@ -69,7 +69,7 @@
         <configuration>
           <mainClass>com.consol.citrus.samples.todolist.TodoApplication</mainClass>
           <useTestClasspath>false</useTestClasspath>
-          <jvmArguments>-Dtodo.persistence.type=jdbc -Dtodo.persistence.server=disabled -Dtodo.jdbc.driverClassName=com.consol.citrus.db.driver.JdbcDriver -Dtodo.jdbc.url=jdbc:citrus:http://localhost:3306/testdb -Dtodo.jdbc.username=user -Dtodo.jdbc.password=password -Dtodo.jdbc.autoCreateTables=false</jvmArguments>
+          <jvmArguments>-Dtodo.persistence.type=jdbc -Dtodo.persistence.server=disabled -Dtodo.jdbc.driverClassName=com.consol.citrus.db.driver.JdbcDriver -Dtodo.jdbc.url=jdbc:citrus:http://localhost:13306/testdb -Dtodo.jdbc.username=user -Dtodo.jdbc.password=password -Dtodo.jdbc.autoCreateTables=false</jvmArguments>
         </configuration>
       </plugin>
 
@@ -97,7 +97,7 @@
                   <TODO_PERSISTENCE_TYPE>jdbc</TODO_PERSISTENCE_TYPE>
                   <TODO_JDBC_AUTO_CREATE_TABLES>false</TODO_JDBC_AUTO_CREATE_TABLES>
                   <TODO_JDBC_DRIVER>com.consol.citrus.db.driver.JdbcDriver</TODO_JDBC_DRIVER>
-                  <TODO_JDBC_URL>jdbc:citrus:http://${env.HOST_IP}:3306/testdb</TODO_JDBC_URL>
+                  <TODO_JDBC_URL>jdbc:citrus:http://${env.HOST_IP}:13306/testdb</TODO_JDBC_URL>
                 </env>
                 <log>
                   <enabled>true</enabled>

--- a/samples-db/sample-jdbc-callable-statements/xml/src/test/resources/citrus-context.xml
+++ b/samples-db/sample-jdbc-callable-statements/xml/src/test/resources/citrus-context.xml
@@ -18,7 +18,7 @@
                         request-url="http://localhost:8080"/>
 
     <citrus-jdbc:server id="jdbcServer"
-                        port="3306"
+                        port="13306"
                         database-name="testdb"
                         timeout="10000"
                         auto-start="true"
@@ -27,7 +27,7 @@
     <!-- JDBC data source -->
     <bean id="todoDataSource" class="org.springframework.jdbc.datasource.SingleConnectionDataSource">
       <property name="driverClassName" value="com.consol.citrus.db.driver.JdbcDriver"/>
-      <property name="url" value="jdbc:citrus:http://localhost:3306/testdb"/>
+      <property name="url" value="jdbc:citrus:http://localhost:13306/testdb"/>
       <property name="username" value="sa"/>
       <property name="password" value=""/>
     </bean>

--- a/samples-db/sample-jdbc-transactions/java-dsl/pom.xml
+++ b/samples-db/sample-jdbc-transactions/java-dsl/pom.xml
@@ -69,7 +69,7 @@
         <configuration>
           <mainClass>com.consol.citrus.samples.todolist.TodoApplication</mainClass>
           <useTestClasspath>false</useTestClasspath>
-          <jvmArguments>-Dtodo.persistence.type=jdbc -Dtodo.persistence.server=disabled -Dtodo.jdbc.driverClassName=com.consol.citrus.db.driver.JdbcDriver -Dtodo.jdbc.url=jdbc:citrus:http://localhost:3306/testdb -Dtodo.persistence.transactional=true -Dtodo.jdbc.username=user -Dtodo.jdbc.password=password -Dtodo.jdbc.autoCreateTables=false</jvmArguments>
+          <jvmArguments>-Dtodo.persistence.type=jdbc -Dtodo.persistence.server=disabled -Dtodo.jdbc.driverClassName=com.consol.citrus.db.driver.JdbcDriver -Dtodo.jdbc.url=jdbc:citrus:http://localhost:13306/testdb -Dtodo.persistence.transactional=true -Dtodo.jdbc.username=user -Dtodo.jdbc.password=password -Dtodo.jdbc.autoCreateTables=false</jvmArguments>
         </configuration>
       </plugin>
 
@@ -98,7 +98,7 @@
                   <TODO_PERSISTENCE_TRANSACTIONAL>true</TODO_PERSISTENCE_TRANSACTIONAL>
                   <TODO_JDBC_AUTO_CREATE_TABLES>false</TODO_JDBC_AUTO_CREATE_TABLES>
                   <TODO_JDBC_DRIVER>com.consol.citrus.db.driver.JdbcDriver</TODO_JDBC_DRIVER>
-                  <TODO_JDBC_URL>jdbc:citrus:http://${env.HOST_IP}:3306/testdb</TODO_JDBC_URL>
+                  <TODO_JDBC_URL>jdbc:citrus:http://${env.HOST_IP}:13306/testdb</TODO_JDBC_URL>
                 </env>
                 <log>
                   <enabled>true</enabled>

--- a/samples-db/sample-jdbc-transactions/java-dsl/src/test/java/com/consol/citrus/samples/todolist/EndpointConfig.java
+++ b/samples-db/sample-jdbc-transactions/java-dsl/src/test/java/com/consol/citrus/samples/todolist/EndpointConfig.java
@@ -54,7 +54,7 @@ public class EndpointConfig {
                 .server()
                 .host("localhost")
                 .databaseName("testdb")
-                .port(3306)
+                .port(13306)
                 .timeout(10000L)
                 .autoStart(true)
                 .autoTransactionHandling(false)
@@ -65,7 +65,7 @@ public class EndpointConfig {
     public SingleConnectionDataSource dataSource() {
         SingleConnectionDataSource dataSource = new SingleConnectionDataSource();
         dataSource.setDriverClassName(JdbcDriver.class.getName());
-        dataSource.setUrl("jdbc:citrus:http://localhost:3306/testdb");
+        dataSource.setUrl("jdbc:citrus:http://localhost:13306/testdb");
         dataSource.setUsername("sa");
         dataSource.setPassword("");
         return dataSource;

--- a/samples-db/sample-jdbc-transactions/xml/pom.xml
+++ b/samples-db/sample-jdbc-transactions/xml/pom.xml
@@ -69,7 +69,7 @@
         <configuration>
           <mainClass>com.consol.citrus.samples.todolist.TodoApplication</mainClass>
           <useTestClasspath>false</useTestClasspath>
-          <jvmArguments>-Dtodo.persistence.type=jdbc -Dtodo.persistence.server=disabled -Dtodo.jdbc.driverClassName=com.consol.citrus.db.driver.JdbcDriver -Dtodo.jdbc.url=jdbc:citrus:http://localhost:3306/testdb -Dtodo.persistence.transactional=true -Dtodo.jdbc.username=user -Dtodo.jdbc.password=password -Dtodo.jdbc.autoCreateTables=false</jvmArguments>
+          <jvmArguments>-Dtodo.persistence.type=jdbc -Dtodo.persistence.server=disabled -Dtodo.jdbc.driverClassName=com.consol.citrus.db.driver.JdbcDriver -Dtodo.jdbc.url=jdbc:citrus:http://localhost:13306/testdb -Dtodo.persistence.transactional=true -Dtodo.jdbc.username=user -Dtodo.jdbc.password=password -Dtodo.jdbc.autoCreateTables=false</jvmArguments>
         </configuration>
       </plugin>
 
@@ -98,7 +98,7 @@
                   <TODO_PERSISTENCE_TRANSACTIONAL>true</TODO_PERSISTENCE_TRANSACTIONAL>
                   <TODO_JDBC_AUTO_CREATE_TABLES>false</TODO_JDBC_AUTO_CREATE_TABLES>
                   <TODO_JDBC_DRIVER>com.consol.citrus.db.driver.JdbcDriver</TODO_JDBC_DRIVER>
-                  <TODO_JDBC_URL>jdbc:citrus:http://${env.HOST_IP}:3306/testdb</TODO_JDBC_URL>
+                  <TODO_JDBC_URL>jdbc:citrus:http://${env.HOST_IP}:13306/testdb</TODO_JDBC_URL>
                 </env>
                 <log>
                   <enabled>true</enabled>

--- a/samples-db/sample-jdbc-transactions/xml/src/test/resources/citrus-context.xml
+++ b/samples-db/sample-jdbc-transactions/xml/src/test/resources/citrus-context.xml
@@ -18,7 +18,7 @@
                         request-url="http://localhost:8080"/>
 
     <citrus-jdbc:server id="jdbcServer"
-                        port="3306"
+                        port="13306"
                         database-name="testdb"
                         timeout="10000"
                         auto-start="true"
@@ -27,7 +27,7 @@
     <!-- JDBC data source -->
     <bean id="todoDataSource" class="org.springframework.jdbc.datasource.SingleConnectionDataSource">
       <property name="driverClassName" value="com.consol.citrus.db.driver.JdbcDriver"/>
-      <property name="url" value="jdbc:citrus:http://localhost:3306/testdb"/>
+      <property name="url" value="jdbc:citrus:http://localhost:13306/testdb"/>
       <property name="username" value="sa"/>
       <property name="password" value=""/>
     </bean>

--- a/samples-db/sample-jdbc/java-dsl/pom.xml
+++ b/samples-db/sample-jdbc/java-dsl/pom.xml
@@ -69,7 +69,7 @@
         <configuration>
           <mainClass>com.consol.citrus.samples.todolist.TodoApplication</mainClass>
           <useTestClasspath>false</useTestClasspath>
-          <jvmArguments>-Dtodo.persistence.type=jdbc -Dtodo.persistence.server=disabled -Dtodo.jdbc.driverClassName=com.consol.citrus.db.driver.JdbcDriver -Dtodo.jdbc.url=jdbc:citrus:http://localhost:3306/testdb -Dtodo.jdbc.username=user -Dtodo.jdbc.password=password -Dtodo.jdbc.autoCreateTables=false</jvmArguments>
+          <jvmArguments>-Dtodo.persistence.type=jdbc -Dtodo.persistence.server=disabled -Dtodo.jdbc.driverClassName=com.consol.citrus.db.driver.JdbcDriver -Dtodo.jdbc.url=jdbc:citrus:http://localhost:13306/testdb -Dtodo.jdbc.username=user -Dtodo.jdbc.password=password -Dtodo.jdbc.autoCreateTables=false</jvmArguments>
         </configuration>
       </plugin>
 

--- a/samples-db/sample-jdbc/java-dsl/src/test/java/com/consol/citrus/samples/todolist/EndpointConfig.java
+++ b/samples-db/sample-jdbc/java-dsl/src/test/java/com/consol/citrus/samples/todolist/EndpointConfig.java
@@ -54,7 +54,7 @@ public class EndpointConfig {
                 .server()
                 .host("localhost")
                 .databaseName("testdb")
-                .port(3306)
+                .port(13306)
                 .timeout(10000L)
                 .autoStart(true)
                 .build();
@@ -64,7 +64,7 @@ public class EndpointConfig {
     public SingleConnectionDataSource dataSource() {
         SingleConnectionDataSource dataSource = new SingleConnectionDataSource();
         dataSource.setDriverClassName(JdbcDriver.class.getName());
-        dataSource.setUrl("jdbc:citrus:http://localhost:3306/testdb");
+        dataSource.setUrl("jdbc:citrus:http://localhost:13306/testdb");
         dataSource.setUsername("sa");
         dataSource.setPassword("");
         return dataSource;

--- a/samples-db/sample-jdbc/xml/pom.xml
+++ b/samples-db/sample-jdbc/xml/pom.xml
@@ -69,7 +69,7 @@
         <configuration>
           <mainClass>com.consol.citrus.samples.todolist.TodoApplication</mainClass>
           <useTestClasspath>false</useTestClasspath>
-          <jvmArguments>-Dtodo.persistence.type=jdbc -Dtodo.persistence.server=disabled -Dtodo.jdbc.driverClassName=com.consol.citrus.db.driver.JdbcDriver -Dtodo.jdbc.url=jdbc:citrus:http://localhost:3306/testdb -Dtodo.jdbc.username=user -Dtodo.jdbc.password=password -Dtodo.jdbc.autoCreateTables=false</jvmArguments>
+          <jvmArguments>-Dtodo.persistence.type=jdbc -Dtodo.persistence.server=disabled -Dtodo.jdbc.driverClassName=com.consol.citrus.db.driver.JdbcDriver -Dtodo.jdbc.url=jdbc:citrus:http://localhost:13306/testdb -Dtodo.jdbc.username=user -Dtodo.jdbc.password=password -Dtodo.jdbc.autoCreateTables=false</jvmArguments>
         </configuration>
       </plugin>
 
@@ -97,7 +97,7 @@
                   <TODO_PERSISTENCE_TYPE>jdbc</TODO_PERSISTENCE_TYPE>
                   <TODO_JDBC_AUTO_CREATE_TABLES>false</TODO_JDBC_AUTO_CREATE_TABLES>
                   <TODO_JDBC_DRIVER>com.consol.citrus.db.driver.JdbcDriver</TODO_JDBC_DRIVER>
-                  <TODO_JDBC_URL>jdbc:citrus:http://${env.HOST_IP}:3306/testdb</TODO_JDBC_URL>
+                  <TODO_JDBC_URL>jdbc:citrus:http://${env.HOST_IP}:13306/testdb</TODO_JDBC_URL>
                 </env>
                 <log>
                   <enabled>true</enabled>

--- a/samples-db/sample-jdbc/xml/src/test/resources/citrus-context.xml
+++ b/samples-db/sample-jdbc/xml/src/test/resources/citrus-context.xml
@@ -18,7 +18,7 @@
                       request-url="http://localhost:8080"/>
 
   <citrus-jdbc:server id="jdbcServer"
-                      port="3306"
+                      port="13306"
                       database-name="testdb"
                       timeout="10000"
                       auto-start="true"/>
@@ -26,7 +26,7 @@
   <!-- JDBC data source -->
   <bean id="todoDataSource" class="org.springframework.jdbc.datasource.SingleConnectionDataSource">
     <property name="driverClassName" value="com.consol.citrus.db.driver.JdbcDriver"/>
-    <property name="url" value="jdbc:citrus:http://localhost:3306/testdb"/>
+    <property name="url" value="jdbc:citrus:http://localhost:13306/testdb"/>
     <property name="username" value="sa"/>
     <property name="password" value=""/>
   </bean>

--- a/samples-remote/sample-test-war/java-dsl/pom.xml
+++ b/samples-remote/sample-test-war/java-dsl/pom.xml
@@ -112,16 +112,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${spring.boot.version}</version>
-        <configuration>
-          <mainClass>com.consol.citrus.samples.todolist.TodoApplication</mainClass>
-          <useTestClasspath>false</useTestClasspath>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
         <version>0.26.0</version>
@@ -323,28 +313,6 @@
       </activation>
       <build>
         <plugins>
-          <plugin>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-maven-plugin</artifactId>
-            <configuration>
-              <fork>true</fork>
-            </configuration>
-            <executions>
-              <execution>
-                <id>pre-integration-test</id>
-                <goals>
-                  <goal>start</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>post-integration-test</id>
-                <goals>
-                  <goal>stop</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-
           <plugin>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-maven-plugin</artifactId>


### PR DESCRIPTION
This pull request adds a travis build pipeline to the project.

Each submodule is executed in a separate target, order is defined explicitly to guarantee that the `todo-app` is first installed in the local maven repository before the integration tests are executed. No other function dependencies between tests exist.

Tests not covered through this pipeline:
- All submodules of submodule `citrus-sample-demo`
- `citrus-[java|xml]-sample-selenium`
- `citrus-[java|xml]-sample-http-loadtest`, see https://github.com/citrusframework/citrus-samples/issues/42
- `citrus-java-sample-test-war`, the configuration of the jetty server seems off

The pipeline consists of 91 stages and has an execution time of roughly 3 hrs. Builds have been tested on [travis-ci.org][TravisOrg] and [travis-ci.com][TravisCom].

[TravisOrg]: https://travis-ci.org/turing85/citrus-samples
[TravisCom]: https://travis-ci.com/turing85/citrus-samples